### PR TITLE
공유 기능에 site 변수 추가

### DIFF
--- a/components/pages/SharePage.tsx
+++ b/components/pages/SharePage.tsx
@@ -137,7 +137,7 @@ const SharePage: React.FC = () => {
                 <div className="text-center text-red-500 bg-red-100 dark:bg-red-900/20 p-6 rounded-lg">
                     <h2 className="text-xl font-bold mb-2">오류</h2>
                     <p>{error}</p>
-                    <Button onClick={() => window.location.href = '/'} className="mt-4">
+                    <Button onClick={() => window.location.href = siteConfig.domain} className="mt-4">
                         홈으로 돌아가기
                     </Button>
                 </div>

--- a/components/pages/SharePage.tsx
+++ b/components/pages/SharePage.tsx
@@ -75,9 +75,11 @@ const SharePage: React.FC = () => {
             const blob = await response.blob();
             const file = new File([blob], `${pageTitle}.png`, { type: blob.type });
 
+            const shareText = `${pageTitle} - ${siteConfig.title}\n\n${shareUrl}`;
+
             await navigator.share({
                 title: pageTitle,
-                text: `${pageTitle} - ${siteConfig.title}`,
+                text: shareText,
                 url: shareUrl,
                 files: [file],
             });

--- a/components/share/ResultImage.tsx
+++ b/components/share/ResultImage.tsx
@@ -1,8 +1,9 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { Question } from '../../types';
 import SimpleSolveTimeChart from './SimpleSolveTimeChart';
 import FinalAnswerSheet from '../review/FinalAnswerSheet';
 import { formatTime } from '../../utils/formatters';
+import { siteConfig } from '../../config/site';
 
 interface ResultImageProps {
   questions: Question[];
@@ -92,7 +93,7 @@ export const ResultImage = forwardRef<HTMLDivElement, ResultImageProps>(
 
         {/* 5. 브랜딩 */}
         <footer className="text-center mt-6 pt-4 border-t border-slate-700">
-          <p className="text-2xl font-bold text-blue-400">mocktimer.kr</p>
+          <p className="text-2xl font-bold text-blue-400">{siteConfig.domain.replace('https://', '')}</p>
           <p className="text-base text-slate-300">나만의 시험 분석 파트너</p>
         </footer>
       </div>

--- a/components/share/ShareButton.tsx
+++ b/components/share/ShareButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { type Question } from '../../types';
 import { Button } from '../ui/Button';
+import { siteConfig } from '../../config/site';
 
 interface ShareButtonProps {
     questions: Question[];
@@ -10,15 +11,15 @@ const ShareButton: React.FC<ShareButtonProps> = ({ questions }) => {
     const [showCopyMessage, setShowCopyMessage] = useState(false);
 
     const handleShare = async () => {
-        const shareText = `모의고사 타이머로 ${questions.length}문제를 풀었습니다. 총 소요시간: ${Math.floor(questions.reduce((sum, q) => sum + q.solveTime, 0) / 60)}분\n\nhttps://www.mocktimer.kr`;
+        const shareText = `모의고사 타이머로 ${questions.length}문제를 풀었습니다. 총 소요시간: ${Math.floor(questions.reduce((sum, q) => sum + q.solveTime, 0) / 60)}분\n\n${siteConfig.domain}`;
         
         if (navigator.share) {
             // 네이티브 공유 API 사용 (모바일)
             try {
                 await navigator.share({
-                    title: '모의고사 타이머 & 분석기',
+                    title: siteConfig.title,
                     text: shareText,
-                    url: 'https://www.mocktimer.kr'
+                    url: siteConfig.domain
                 });
             } catch (error) {
                 console.log('공유가 취소되었습니다.');

--- a/components/share/ShareImageButton.tsx
+++ b/components/share/ShareImageButton.tsx
@@ -98,7 +98,7 @@ const ShareImageButton: React.FC<ShareImageButtonProps> = ({ questions, examName
                 return response.json();
             })
             .then(data => {
-                const newShareUrl = `${window.location.origin}/share/${data.id}`;
+                const newShareUrl = `${siteConfig.domain}/share/${data.id}`;
                 setShareUrl(newShareUrl);
             })
             .catch(err => {

--- a/components/share/ShareImageButton.tsx
+++ b/components/share/ShareImageButton.tsx
@@ -4,7 +4,7 @@ import { type Question } from '../../types';
 import { Button } from '../ui/Button';
 import ShareSettingsModal from './ShareSettingsModal';
 import SharePreviewModal from './SharePreviewModal';
-import { siteConfig } from '../../config/site';
+import { siteConfig, getCurrentDomain } from '../../config/site';
 import { ResultImage } from '../share/ResultImage'; // ResultImage를 직접 사용하기 위해 import
 
 interface ShareImageButtonProps {
@@ -98,7 +98,7 @@ const ShareImageButton: React.FC<ShareImageButtonProps> = ({ questions, examName
                 return response.json();
             })
             .then(data => {
-                const newShareUrl = `${siteConfig.domain}/share/${data.id}`;
+                const newShareUrl = `${getCurrentDomain()}/share/${data.id}`;
                 setShareUrl(newShareUrl);
             })
             .catch(err => {

--- a/components/share/ShareImageButton.tsx
+++ b/components/share/ShareImageButton.tsx
@@ -121,14 +121,32 @@ const ShareImageButton: React.FC<ShareImageButtonProps> = ({ questions, examName
         }
         setIsSharing(true);
         try {
+            const shareText = `${examName} 시험 결과 - ${siteConfig.title}\n\n${shareUrl}`;
+            
             if (navigator.share && navigator.canShare && navigator.canShare({ files: [generatedImageFile] })) {
                 await navigator.share({
                     title: `${examName} 시험 결과 - ${siteConfig.title}`,
-                    text: `${examName} 시험 결과 - ${siteConfig.title}`,
+                    text: shareText,
                     url: shareUrl,
                     files: [generatedImageFile],
                 });
             } else {
+                // 폴백: 클립보드에 텍스트와 링크 복사 후 이미지 다운로드
+                try {
+                    await navigator.clipboard.writeText(shareText);
+                    alert('공유 텍스트와 링크가 클립보드에 복사되었습니다!');
+                } catch (error) {
+                    // 폴백: 수동 복사
+                    const textArea = document.createElement('textarea');
+                    textArea.value = shareText;
+                    document.body.appendChild(textArea);
+                    textArea.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(textArea);
+                    alert('공유 텍스트와 링크가 클립보드에 복사되었습니다!');
+                }
+                
+                // 이미지 다운로드
                 const downloadUrl = window.URL.createObjectURL(generatedImageFile);
                 const a = document.createElement('a');
                 a.href = downloadUrl;

--- a/components/share/ShareImageButton.tsx
+++ b/components/share/ShareImageButton.tsx
@@ -4,7 +4,7 @@ import { type Question } from '../../types';
 import { Button } from '../ui/Button';
 import ShareSettingsModal from './ShareSettingsModal';
 import SharePreviewModal from './SharePreviewModal';
-import { siteConfig, getCurrentDomain } from '../../config/site';
+import { siteConfig } from '../../config/site';
 import { ResultImage } from '../share/ResultImage'; // ResultImage를 직접 사용하기 위해 import
 
 interface ShareImageButtonProps {
@@ -98,7 +98,7 @@ const ShareImageButton: React.FC<ShareImageButtonProps> = ({ questions, examName
                 return response.json();
             })
             .then(data => {
-                const newShareUrl = `${getCurrentDomain()}/share/${data.id}`;
+                const newShareUrl = `${siteConfig.domain}/share/${data.id}`;
                 setShareUrl(newShareUrl);
             })
             .catch(err => {

--- a/config/site.ts
+++ b/config/site.ts
@@ -56,20 +56,6 @@ export const siteConfig = {
 // URL 생성 헬퍼 함수들
 export const getShareUrl = (path: string = '') => `${siteConfig.domain}${path}`;
 
-// 환경에 따른 동적 도메인 결정 (개발 환경에서는 현재 도메인, 프로덕션에서는 설정된 도메인)
-export const getCurrentDomain = () => {
-    if (typeof window !== 'undefined') {
-        // 개발 환경에서는 현재 도메인 사용 (localhost, 개발 서버 등)
-        if (window.location.hostname === 'localhost' || 
-            window.location.hostname.includes('dev') || 
-            window.location.hostname.includes('staging')) {
-            return window.location.origin;
-        }
-    }
-    // 프로덕션 환경에서는 설정된 도메인 사용
-    return siteConfig.domain;
-};
-
 export const getTwitterShareUrl = (text?: string, url?: string) => {
     const shareText = text || siteConfig.shareText;
     const shareUrl = url || siteConfig.domain;

--- a/config/site.ts
+++ b/config/site.ts
@@ -56,6 +56,20 @@ export const siteConfig = {
 // URL 생성 헬퍼 함수들
 export const getShareUrl = (path: string = '') => `${siteConfig.domain}${path}`;
 
+// 환경에 따른 동적 도메인 결정 (개발 환경에서는 현재 도메인, 프로덕션에서는 설정된 도메인)
+export const getCurrentDomain = () => {
+    if (typeof window !== 'undefined') {
+        // 개발 환경에서는 현재 도메인 사용 (localhost, 개발 서버 등)
+        if (window.location.hostname === 'localhost' || 
+            window.location.hostname.includes('dev') || 
+            window.location.hostname.includes('staging')) {
+            return window.location.origin;
+        }
+    }
+    // 프로덕션 환경에서는 설정된 도메인 사용
+    return siteConfig.domain;
+};
+
 export const getTwitterShareUrl = (text?: string, url?: string) => {
     const shareText = text || siteConfig.shareText;
     const shareUrl = url || siteConfig.domain;

--- a/config/site.ts
+++ b/config/site.ts
@@ -56,6 +56,21 @@ export const siteConfig = {
 // URL 생성 헬퍼 함수들
 export const getShareUrl = (path: string = '') => `${siteConfig.domain}${path}`;
 
+// 환경에 따른 동적 도메인 결정 (개발 환경에서는 현재 도메인, 프로덕션에서는 설정된 도메인)
+// 필요시 사용: const shareUrl = getCurrentDomain() + '/share/' + id;
+export const getCurrentDomain = () => {
+    if (typeof window !== 'undefined') {
+        // 개발 환경에서는 현재 도메인 사용 (localhost, 개발 서버 등)
+        if (window.location.hostname === 'localhost' || 
+            window.location.hostname.includes('dev') || 
+            window.location.hostname.includes('staging')) {
+            return window.location.origin;
+        }
+    }
+    // 프로덕션 환경에서는 설정된 도메인 사용
+    return siteConfig.domain;
+};
+
 export const getTwitterShareUrl = (text?: string, url?: string) => {
     const shareText = text || siteConfig.shareText;
     const shareUrl = url || siteConfig.domain;


### PR DESCRIPTION
<!-- Standardize domain usage across sharing features and enhance shared text to include links, with a robust fallback. -->

<!-- This PR addresses inconsistencies in domain usage across sharing features, previously relying on hardcoded URLs or `window.location.origin`. By standardizing on `siteConfig.domain`, domain management is centralized, improving consistency and SEO. Furthermore, shared text now consistently includes the relevant link, and a robust fallback (clipboard copy + image download) is implemented for environments lacking native share API support. The 'Go to Home' button on the share page also now uses `siteConfig.domain`. -->