### PR TITLE
모바일 결과 페이지 좌우 스크롤 수정

### DIFF
--- a/components/pages/SharePage.tsx
+++ b/components/pages/SharePage.tsx
@@ -119,13 +119,13 @@ const SharePage: React.FC = () => {
     }, [id]);
 
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen bg-slate-50 dark:bg-slate-950 py-10">
+        <div className="flex flex-col items-center justify-center min-h-screen bg-slate-50 dark:bg-slate-950 py-10 px-4 overflow-x-hidden">
             <Helmet>
                 <title>{pageTitle} - {siteConfig.title}</title>
                 <meta name="description" content={`${pageTitle}를 확인하고 공유해보세요.`} />
             </Helmet>
 
-            <div className="text-center mb-8">
+            <div className="text-center mb-8 w-full max-w-md">
                 <Link to="/" className="text-2xl font-bold text-primary-600 dark:text-primary-400 hover:underline">
                     {siteConfig.title}
                 </Link>
@@ -134,7 +134,7 @@ const SharePage: React.FC = () => {
 
             {loading && <Spinner />}
             {error && (
-                <div className="text-center text-red-500 bg-red-100 dark:bg-red-900/20 p-6 rounded-lg">
+                <div className="text-center text-red-500 bg-red-100 dark:bg-red-900/20 p-6 rounded-lg w-full max-w-md">
                     <h2 className="text-xl font-bold mb-2">오류</h2>
                     <p>{error}</p>
                     <Button onClick={() => window.location.href = '/'} className="mt-4">
@@ -143,7 +143,7 @@ const SharePage: React.FC = () => {
                 </div>
             )}
             {resultData && (
-                 <div className="bg-white dark:bg-slate-900 p-4 sm:p-6 rounded-xl shadow-lg border border-slate-200 dark:border-slate-800">
+                 <div className="bg-white dark:bg-slate-900 p-4 sm:p-6 rounded-xl shadow-lg border border-slate-200 dark:border-slate-800 w-full max-w-full overflow-hidden">
                     <ResultImage
                         questions={resultData.questions}
                         examName={resultData.examName}
@@ -154,7 +154,7 @@ const SharePage: React.FC = () => {
                 </div>
             )}
 
-            <div className="mt-8 flex flex-col items-center gap-4">
+            <div className="mt-8 flex flex-col items-center gap-4 w-full px-4">
                 <div className="flex w-full max-w-sm gap-2">
                     <Button onClick={handleCopyLink} variant="outline" className="flex-1">
                         {isCopied ? '복사 완료!' : '링크 복사'}

--- a/components/review/FinalAnswerSheet.tsx
+++ b/components/review/FinalAnswerSheet.tsx
@@ -30,8 +30,8 @@ const FinalAnswerSheet: React.FC<FinalAnswerSheetProps> = ({ questions, blurAnsw
     
     // Tailwind JIT requires full class names
     const getGridClass = () => {
-        if (forceCols === 10) return 'grid-cols-10';
-        if (forceCols === 15) return 'grid-cols-15';
+        if (forceCols === 10) return 'grid-cols-5 sm:grid-cols-8 md:grid-cols-10';
+        if (forceCols === 15) return 'grid-cols-5 sm:grid-cols-10 md:grid-cols-15';
         // Default responsive behavior
         return 'grid-cols-5 sm:grid-cols-10 lg:grid-cols-15';
     }
@@ -42,11 +42,11 @@ const FinalAnswerSheet: React.FC<FinalAnswerSheetProps> = ({ questions, blurAnsw
             {sortedQuestions.map(q => (
                 <div
                     key={`answer-grid-${q.number}`}
-                    className={`p-1.5 rounded-md flex flex-col items-center justify-center text-center border transition-colors ${getStyles(q)}`}
+                    className={`p-1 sm:p-1.5 rounded-md flex flex-col items-center justify-center text-center border transition-colors ${getStyles(q)}`}
                 >
-                    <span className="text-sm font-medium text-slate-500 dark:text-slate-400">{q.number}</span>
+                    <span className="text-xs sm:text-sm font-medium text-slate-500 dark:text-slate-400">{q.number}</span>
                     <span
-                        className={`text-base font-bold text-slate-800 dark:text-slate-200 truncate ${blurAnswer ? 'blur-sm select-none' : ''}`}
+                        className={`text-sm sm:text-base font-bold text-slate-800 dark:text-slate-200 truncate ${blurAnswer ? 'blur-sm select-none' : ''}`}
                     >
                         {q.answer ?? '-'}
                     </span>

--- a/components/share/ResultImage.tsx
+++ b/components/share/ResultImage.tsx
@@ -27,35 +27,35 @@ export const ResultImage = forwardRef<HTMLDivElement, ResultImageProps>(
       // 세로형 이미지의 전체 크기와 스타일 지정
       <div 
         ref={ref} 
-        className="bg-slate-900 text-white p-6" 
-        style={{ width: 580, fontFamily: "'Noto Sans KR', sans-serif" }}
+        className="bg-slate-900 text-white p-4 sm:p-6 w-full max-w-full" 
+        style={{ fontFamily: "'Noto Sans KR', sans-serif" }}
         data-testid="result-image-container"
       >
         
         <header className="text-center mb-6">
-          <h1 className="text-3xl font-bold text-white">{examName}</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-white">{examName}</h1>
         </header>
         
         {/* 2. 결과 요약 */}
         <section className="bg-slate-800/80 p-4 rounded-lg mb-6 border border-slate-700">
-          <h2 className="text-2xl font-semibold mb-3 text-center text-slate-200">결과 요약</h2>
+          <h2 className="text-xl sm:text-2xl font-semibold mb-3 text-center text-slate-200">결과 요약</h2>
           <div className="grid grid-cols-2 gap-4 text-center">
             <div className="bg-slate-700/50 p-3 rounded-md">
-              <p className="text-slate-300 text-base">총 소요 시간</p>
-              <p className="text-3xl font-bold text-white">{formatTime(totalTime)}</p>
+              <p className="text-slate-300 text-sm sm:text-base">총 소요 시간</p>
+              <p className="text-2xl sm:text-3xl font-bold text-white">{formatTime(totalTime)}</p>
             </div>
             <div className="bg-slate-700/50 p-3 rounded-md">
               {includeGrading && gradedQuestions.length > 0 ? (
                 <>
-                  <p className="text-slate-300 text-base">채점 결과</p>
-                  <p className="text-3xl font-bold">
+                  <p className="text-slate-300 text-sm sm:text-base">채점 결과</p>
+                  <p className="text-2xl sm:text-3xl font-bold">
                     <span className="text-green-400">{correctCount}</span> / {gradedQuestions.length}
                   </p>
                 </>
               ) : (
                 <>
-                  <p className="text-slate-300 text-base">시험 전체 시간</p>
-                  <p className="text-3xl font-bold">
+                  <p className="text-slate-300 text-sm sm:text-base">시험 전체 시간</p>
+                  <p className="text-2xl sm:text-3xl font-bold">
                     {totalMinutes ? `${totalMinutes}분` : '-'}
                   </p>
                 </>
@@ -84,7 +84,7 @@ export const ResultImage = forwardRef<HTMLDivElement, ResultImageProps>(
 
         {/* 4. 풀이 시간 그래프 */}
         <section className="mb-4 bg-slate-800/60 p-4 rounded-lg border border-slate-700">
-             <h2 className="text-2xl font-semibold mb-3 text-center text-slate-200">풀이 시간 그래프</h2>
+             <h2 className="text-xl sm:text-2xl font-semibold mb-3 text-center text-slate-200">풀이 시간 그래프</h2>
              <div style={{ height: 250 }}>
                 <SimpleSolveTimeChart questions={questions} />
              </div>
@@ -92,8 +92,8 @@ export const ResultImage = forwardRef<HTMLDivElement, ResultImageProps>(
 
         {/* 5. 브랜딩 */}
         <footer className="text-center mt-6 pt-4 border-t border-slate-700">
-          <p className="text-2xl font-bold text-blue-400">mocktimer.kr</p>
-          <p className="text-base text-slate-300">나만의 시험 분석 파트너</p>
+          <p className="text-xl sm:text-2xl font-bold text-blue-400">mocktimer.kr</p>
+          <p className="text-sm sm:text-base text-slate-300">나만의 시험 분석 파트너</p>
         </footer>
       </div>
     );

--- a/components/share/SimpleSolveTimeChart.tsx
+++ b/components/share/SimpleSolveTimeChart.tsx
@@ -45,11 +45,11 @@ const SimpleSolveTimeChart: React.FC<SimpleSolveTimeChartProps> = ({ questions }
     const barSize = solveOrderData.length < 10 ? 40 : undefined;
 
     return (
-        <div className="w-full h-64">
+        <div className="w-full h-48 sm:h-64">
             <Recharts.ResponsiveContainer width="100%" height="100%">
                 <Recharts.ComposedChart
                     data={solveOrderData}
-                    margin={{ top: 10, right: 30, left: 20, bottom: 10 }}
+                    margin={{ top: 10, right: 20, left: 10, bottom: 10 }}
                 >
                     <Recharts.CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
                     <Recharts.XAxis 
@@ -66,7 +66,7 @@ const SimpleSolveTimeChart: React.FC<SimpleSolveTimeChartProps> = ({ questions }
                             angle: -90, 
                             position: 'insideLeft', 
                             fill: tickColor, 
-                            style: {textAnchor: 'middle', fontSize: 12} 
+                            style: {textAnchor: 'middle', fontSize: 10} 
                         }} 
                     />
                     <Recharts.YAxis 
@@ -78,7 +78,7 @@ const SimpleSolveTimeChart: React.FC<SimpleSolveTimeChartProps> = ({ questions }
                             angle: 90, 
                             position: 'insideRight', 
                             fill: tickColor, 
-                            style: {textAnchor: 'middle', fontSize: 12} 
+                            style: {textAnchor: 'middle', fontSize: 10} 
                         }}
                         tickFormatter={formatMinute}
                     />


### PR DESCRIPTION
<!-- Make the result sharing page responsive on mobile to prevent horizontal scrolling, while preserving the original image capture size. -->