### PR TITLE
하단 mocktimer.kr 링크 업데이트

### DIFF
--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -97,6 +97,34 @@ export const Navigation: React.FC<NavigationProps> = ({ scale, setScale }) => {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
             </svg>
           </Button>
+          
+          {/* 화면 배율 캡슐 */}
+          <div className="flex items-center bg-slate-100 dark:bg-slate-700/50 rounded-full overflow-hidden">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleScaleChange('decrease')}
+              aria-label="화면 축소"
+              className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
+              style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
+            >
+              <span className="leading-none">−</span>
+            </Button>
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 px-2 tabular-nums whitespace-nowrap" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
+              {scale}%
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleScaleChange('increase')}
+              aria-label="화면 확대"
+              className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
+              style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
+            >
+              <span className="leading-none">+</span>
+            </Button>
+          </div>
+          
           <Button 
             variant="ghost" 
             size="icon" 

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -66,6 +66,33 @@ export const Navigation: React.FC<NavigationProps> = ({ scale, setScale }) => {
           </p>
             </div>
         <div className="flex-shrink-0 flex items-center gap-2">
+          {/* 화면 배율 캡슐 */}
+          <div className="flex items-center bg-slate-100 dark:bg-slate-700/50 rounded-full overflow-hidden">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleScaleChange('decrease')}
+              aria-label="화면 축소"
+              className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
+              style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
+            >
+              <span className="leading-none">−</span>
+            </Button>
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 px-2 tabular-nums whitespace-nowrap" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
+              {scale}%
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleScaleChange('increase')}
+              aria-label="화면 확대"
+              className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
+              style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
+            >
+              <span className="leading-none">+</span>
+            </Button>
+          </div>
+          
           <Button 
             variant="ghost" 
             size="icon" 
@@ -97,33 +124,6 @@ export const Navigation: React.FC<NavigationProps> = ({ scale, setScale }) => {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
             </svg>
           </Button>
-          
-          {/* 화면 배율 캡슐 */}
-          <div className="flex items-center bg-slate-100 dark:bg-slate-700/50 rounded-full overflow-hidden">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => handleScaleChange('decrease')}
-              aria-label="화면 축소"
-              className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
-              style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
-            >
-              <span className="leading-none">−</span>
-            </Button>
-            <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 px-2 tabular-nums whitespace-nowrap" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
-              {scale}%
-            </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => handleScaleChange('increase')}
-              aria-label="화면 확대"
-              className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
-              style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
-            >
-              <span className="leading-none">+</span>
-            </Button>
-          </div>
           
           <Button 
             variant="ghost" 

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -122,22 +122,23 @@ export const Navigation: React.FC<NavigationProps> = ({ scale, setScale }) => {
             </Button>
             {showMenu && (
               <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 z-50">
-                <div className="p-2 border-b border-slate-200 dark:border-slate-700">
-                  <div className="flex items-center justify-between gap-1">
-                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 px-2">
+                <div className="p-3 border-b border-slate-200 dark:border-slate-700">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 whitespace-nowrap">
                       화면 배율
                     </span>
-                    <div className="flex items-center gap-1 bg-slate-100 dark:bg-slate-700/50 rounded-full">
+                    <div className="flex items-center bg-slate-100 dark:bg-slate-700/50 rounded-full overflow-hidden">
                       <Button
                         variant="ghost"
                         size="icon"
                         onClick={() => handleScaleChange('decrease')}
                         aria-label="화면 축소"
-                        className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8"
+                        className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
+                        style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
                       >
-                        -
+                        <span className="leading-none">−</span>
                       </Button>
-                      <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 w-12 text-center tabular-nums">
+                      <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 px-2 tabular-nums whitespace-nowrap" style={{ fontSize: 'clamp(0.75rem, 1.8vw, 0.875rem)' }}>
                         {scale}%
                       </span>
                       <Button
@@ -145,9 +146,10 @@ export const Navigation: React.FC<NavigationProps> = ({ scale, setScale }) => {
                         size="icon"
                         onClick={() => handleScaleChange('increase')}
                         aria-label="화면 확대"
-                        className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8"
+                        className="text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100 !w-8 !h-8 !p-0 flex items-center justify-center"
+                        style={{ fontSize: 'clamp(0.875rem, 2vw, 1rem)' }}
                       >
-                        +
+                        <span className="leading-none">+</span>
                       </Button>
                     </div>
                   </div>

--- a/components/share/ResultImage.tsx
+++ b/components/share/ResultImage.tsx
@@ -98,7 +98,14 @@ export const ResultImage = forwardRef<HTMLDivElement, ResultImageProps>(
 
         {/* 5. 브랜딩 */}
         <footer className="text-center mt-6 pt-4 border-t border-slate-700">
-          <p className="text-2xl font-bold text-blue-400">{siteConfig.domain.replace('https://', '')}</p>
+          <a 
+            href={siteConfig.domain} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="text-2xl font-bold text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            mock timer.kr
+          </a>
           <p className="text-base text-slate-300">나만의 시험 분석 파트너</p>
         </footer>
       </div>

--- a/components/share/ResultImage.tsx
+++ b/components/share/ResultImage.tsx
@@ -104,7 +104,7 @@ export const ResultImage = forwardRef<HTMLDivElement, ResultImageProps>(
             rel="noopener noreferrer"
             className="text-2xl font-bold text-blue-400 hover:text-blue-300 transition-colors"
           >
-            mock timer.kr
+            mocktimer.kr
           </a>
           <p className="text-base text-slate-300">나만의 시험 분석 파트너</p>
         </footer>

--- a/components/share/ResultImageDisplay.tsx
+++ b/components/share/ResultImageDisplay.tsx
@@ -123,7 +123,14 @@ export const ResultImageDisplay = forwardRef<HTMLDivElement, ResultImageDisplayP
 
         {/* 5. 브랜딩 */}
         <footer className="text-center mt-6 pt-4 border-t border-slate-700">
-          <p className="text-2xl font-bold text-blue-400">{siteConfig.domain.replace('https://', '')}</p>
+          <a 
+            href={siteConfig.domain} 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="text-2xl font-bold text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            mocktimer.kr
+          </a>
           <p className="text-base text-slate-300">나만의 시험 분석 파트너</p>
         </footer>
         </div>

--- a/components/share/SharePreviewModal.tsx
+++ b/components/share/SharePreviewModal.tsx
@@ -51,7 +51,13 @@ const SharePreviewModal: React.FC<SharePreviewModalProps> = ({
 
     return createPortal(
         <div className="fixed inset-0 z-[100] bg-black/60 flex items-center justify-center p-4">
-            <div className="bg-white dark:bg-slate-900 rounded-xl shadow-xl flex flex-col max-h-full w-full max-w-lg overflow-hidden">
+            <div 
+                className="bg-white dark:bg-slate-900 rounded-xl shadow-xl flex flex-col w-full max-w-lg overflow-hidden" 
+                style={{ 
+                    maxHeight: 'calc(100vh - 2rem)',
+                    minHeight: '400px'
+                }}
+            >
                 {/* Header */}
                 <div className="flex-shrink-0 p-4 border-b border-slate-200 dark:border-slate-700 flex justify-between items-center">
                     <h3 className="text-lg font-bold text-slate-800 dark:text-slate-200">결과 공유하기</h3>
@@ -61,8 +67,8 @@ const SharePreviewModal: React.FC<SharePreviewModalProps> = ({
                 </div>
 
                 {/* Main Scrollable Content */}
-                <div className="flex-grow overflow-y-auto">
-                    <div className="relative p-4 sm:p-6 flex flex-col justify-center items-center bg-slate-100 dark:bg-slate-800/20 min-h-[320px]">
+                <div className="flex-grow overflow-y-auto min-h-0">
+                    <div className="relative p-4 sm:p-6 flex flex-col justify-center items-center bg-slate-100 dark:bg-slate-800/20" style={{ minHeight: '280px' }}>
                         {(isLoading || error) && (
                             <div className="absolute inset-4 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm flex flex-col items-center justify-center p-4 text-center transition-opacity rounded-xl">
                                 {isLoading && (
@@ -91,24 +97,32 @@ const SharePreviewModal: React.FC<SharePreviewModalProps> = ({
                 </div>
                 
                 {/* Footer Buttons */}
-                <div className="flex-shrink-0 p-4 border-t border-slate-200 dark:border-slate-700 space-y-4">
-                    <div className="space-y-2">
-                         <div className="flex items-center justify-between w-full h-12 bg-slate-100 dark:bg-slate-800 rounded-md px-3">
+                <div className="flex-shrink-0 p-4 border-t border-slate-200 dark:border-slate-700 space-y-3">
+                    {/* URL Display and Copy Button */}
+                    <div className="bg-slate-100 dark:bg-slate-800 rounded-md p-3">
+                        <div className="flex items-center justify-between gap-2">
                             {isUrlLoading ? (
-                                <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400">
+                                <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400 min-w-0 flex-1">
                                     <Spinner size="sm" />
-                                    <span>링크 생성 중...</span>
+                                    <span className="text-sm">링크 생성 중...</span>
                                 </div>
                             ) : (
-                                <span className="flex-grow text-sm text-slate-800 dark:text-slate-200 truncate">
+                                <span className="flex-grow text-sm text-slate-800 dark:text-slate-200 truncate min-w-0">
                                     {shareUrl || '오류: 링크를 생성할 수 없습니다.'}
                                 </span>
                             )}
-                            <Button onClick={onCopy} variant={isCopied ? "success" : "secondary"} disabled={!shareUrl || isUrlLoading} className="ml-2 flex-shrink-0 px-3 py-1 text-sm">
+                            <Button 
+                                onClick={onCopy} 
+                                variant={isCopied ? "success" : "secondary"} 
+                                disabled={!shareUrl || isUrlLoading} 
+                                className="flex-shrink-0 px-3 py-1.5 text-sm whitespace-nowrap"
+                            >
                                 {isCopied ? '복사됨' : '복사'}
                             </Button>
                         </div>
                     </div>
+                    
+                    {/* Action Buttons */}
                     <div className="flex gap-2">
                         {showSettingsButton && (
                             <Button onClick={onBackToSettings} className="flex-1" variant="outline" disabled={isLoading || isUrlLoading || isSharing}>


### PR DESCRIPTION
Enhance UI for branding link, share preview modal, and navigation scale controls.

*   Updated branding domain to "mocktimer.kr" and made it a clickable link in `ResultImage.tsx` and `ResultImageDisplay.tsx`.
*   Improved responsiveness and layout of the share preview modal's link copy section and overall modal height in `SharePreviewModal.tsx` to prevent UI overflow on scaling.
*   Enhanced the UI of navigation scale adjustment buttons in `Navigation.tsx` for better alignment and responsiveness, and added a top-level scale control next to the share button for easier access and synchronization.